### PR TITLE
Add GCP Terraform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
  * Linux binary and systemd script
  * Docker container
  * Kubernetes helm chart
- * AWS and Azure terraform scripts
+ * AWS, Azure and GCP terraform scripts
 
 ## How to use
 

--- a/examples/terraform/gcp/README.md
+++ b/examples/terraform/gcp/README.md
@@ -1,0 +1,44 @@
+# Terraform GCP deployment
+
+These Terraform files can be used in Docker agent deployment to GCE spot instances running Container-Optimized OS.
+
+## To use this Terraform code you need
+
+* [gcloud sdk](https://cloud.google.com/sdk/docs/install) to be installed on your PC
+* [terraform](https://www.terraform.io/downloads) to be installed on your PC
+* configured `.tfvars` file. See `example.tfvars` as an example of configuring
+
+## Useful information
+
+New Google Cloud Platform users receive 300 USD credits for basic usage. So, we can use these credits for agent deployment. Though GCP free plan has limitations, such as 12 vCPU total, 4 public IPs per zone and 8 vCPU per zone. 
+
+Payed accounts can use this code on full power, providing support for more VM instances in more regions.
+In example provided, we use 12 VMs in 3 different availability zones. You can customize it as you wish.
+
+## Example of using Terraform for GCP
+
+**Login into GCP account from CLI**
+
+`$ gcloud auth application-default login`
+
+**Initialize terraform modules**
+
+`$ terraform init`
+
+**Deploy agent**
+
+`$ terraform apply -auto-approve -var-file example.tfvars`
+
+## Verify if agent is running properly
+
+1. You can list VMs in your account using
+
+`$ gcloud compute instances list`
+
+2. Connect to the instance via SSH
+
+`$ ssh user@<instance-ip>` OR `$ gcloud compute ssh <instance-name>`
+
+3. View agent's logs
+
+`$ docker logs -f mg-agent`

--- a/examples/terraform/gcp/README.md
+++ b/examples/terraform/gcp/README.md
@@ -7,6 +7,7 @@ These Terraform files can be used in Docker agent deployment to GCE spot instanc
 * [gcloud sdk](https://cloud.google.com/sdk/docs/install) to be installed on your PC
 * [terraform](https://www.terraform.io/downloads) to be installed on your PC
 * configured `.tfvars` file. See `example.tfvars` as an example of configuring
+* Compute Engine API must be enabled on your GCP account
 
 ## Useful information
 

--- a/examples/terraform/gcp/example.tfvars
+++ b/examples/terraform/gcp/example.tfvars
@@ -1,0 +1,5 @@
+name           = "mg-agent"
+gcp_project    = "mg-agent-test"
+instance_zones = ["europe-central2-a", "europe-west4-b", "europe-west2-c"]
+instance_count = 4
+instance_type  = "n1-standard-1"

--- a/examples/terraform/gcp/main.tf
+++ b/examples/terraform/gcp/main.tf
@@ -1,0 +1,60 @@
+provider "google" {
+  project = var.gcp_project
+}
+
+resource "google_service_account" "mg" {
+  project      = var.gcp_project
+  account_id   = "compute-sa"
+  display_name = "SA for Google Compute Engine"
+}
+
+resource "google_compute_instance_template" "mg" {
+  provider     = google-beta
+  project      = var.gcp_project
+  name         = "${var.name}-template"
+  machine_type = var.instance_type
+  tags         = ["default-allow-ssh"]
+
+  metadata = {
+    ssh-keys = "user:${file("~/.ssh/id_rsa.pub")}"
+  }
+
+  metadata_startup_script = <<SCRIPT
+    sleep 10
+    docker run --detach --restart always --pull always --net host --name mg-agent vladstarr/mg-agent:latest
+  SCRIPT
+
+  disk {
+    source_image = "cos-cloud/cos-stable"
+    auto_delete  = true
+    boot         = true
+  }
+
+  service_account {
+    email  = google_service_account.mg.email
+    scopes = ["cloud-platform"]
+  }
+
+  network_interface {
+    network = "default"
+    access_config {}
+  }
+
+  scheduling {
+    preemptible        = true
+    automatic_restart  = false
+    provisioning_model = "SPOT"
+  }
+}
+
+module "agent" {
+  source = "./modules/agent"
+
+  for_each = var.instance_zones
+
+  gcp_project          = var.gcp_project
+  name                 = var.name
+  instance_count       = var.instance_count
+  instance_zone        = each.key
+  instance_template_id = google_compute_instance_template.mg.id
+}

--- a/examples/terraform/gcp/modules/agent/main.tf
+++ b/examples/terraform/gcp/modules/agent/main.tf
@@ -1,0 +1,15 @@
+resource "google_compute_instance_group_manager" "mg" {
+  provider = google-beta
+  project  = var.gcp_project
+  name     = var.name
+
+  base_instance_name = var.name
+  zone               = var.instance_zone
+  target_size        = var.instance_count
+
+  wait_for_instances = true
+
+  version {
+    instance_template = var.instance_template_id
+  }
+}

--- a/examples/terraform/gcp/modules/agent/provider.tf
+++ b/examples/terraform/gcp/modules/agent/provider.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "= 4.15.0"
+    }
+  }
+}

--- a/examples/terraform/gcp/modules/agent/variables.tf
+++ b/examples/terraform/gcp/modules/agent/variables.tf
@@ -1,0 +1,20 @@
+variable "instance_count" {
+  type        = string
+  description = "Compute Engine instance count"
+}
+variable "instance_zone" {
+  type        = string
+  description = "Compute Engine instance zone"
+}
+variable "instance_template_id" {
+  type        = string
+  description = "Compute Engine instance template id"
+}
+variable "gcp_project" {
+  type        = string
+  description = "Google Cloud Platform project name"
+}
+variable "name" {
+  type        = string
+  description = "Deployment name"
+}

--- a/examples/terraform/gcp/provider.tf
+++ b/examples/terraform/gcp/provider.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "= 4.15.0"
+    }
+  }
+}

--- a/examples/terraform/gcp/variables.tf
+++ b/examples/terraform/gcp/variables.tf
@@ -1,0 +1,20 @@
+variable "instance_count" {
+  type        = string
+  description = "Compute Engine instance count"
+}
+variable "gcp_project" {
+  type        = string
+  description = "Google Cloud Platform project name"
+}
+variable "instance_zones" {
+  type        = set(string)
+  description = "List of compute zones"
+}
+variable "instance_type" {
+  type        = string
+  description = "Compute Engine instance type"
+}
+variable "name" {
+  type        = string
+  description = "Deployment name"
+}


### PR DESCRIPTION
This merge will add support for agent's deployment on Google Cloud Platform using Terraform.